### PR TITLE
Plan .NET 10 re-creation as 12 ordered OpenSpec changes

### DIFF
--- a/openspec/ROADMAP.md
+++ b/openspec/ROADMAP.md
@@ -1,0 +1,83 @@
+# Pisum Whisper — change sequence
+
+Re-creation of `W:\github-pisum-transcript` (Tauri 2 + Svelte 5) as a .NET 10 application for
+Windows x64 and macOS Apple Silicon. Cloud-only, Gemini-only: local Whisper inference is out of
+scope despite the repository name.
+
+Target pipeline:
+
+```
+global hotkey (hold or toggle) -> mic capture -> Opus/WAV encode
+  -> Gemini upload with the active preset's system prompt
+  -> clipboard + synthetic Ctrl+V / Cmd+V at the cursor
+```
+
+plus a tray icon with idle and recording states, a settings window, rolling file logging, and autostart.
+
+## Dependency graph
+
+```
+ 1 bootstrap-solution
+    |-- 2 add-settings-store
+    |      |-- 3 add-file-logging
+    |      +-- 6 add-global-hotkey
+    |-- 4 add-audio-pipeline ---- 5 add-gemini-transcription   (also needs 2)
+    +-- 7 add-text-output
+                        |
+            8 add-dictation-pipeline      needs 4, 5, 6, 7   <-- first end-to-end dictation
+                        |
+            9 add-tray-icon               needs 8
+                        |
+           10 add-settings-window         needs 2, 3, 5, 6, 9
+                        |
+           11 add-system-integration      needs 2, 8, 10
+                        |
+           12 add-packaging-ci            needs all
+```
+
+After #1, changes **2 / 4 / 7** are independent and may run in parallel; after #2, **3 / 6** likewise.
+Everything from #8 onward is strictly sequential.
+
+## Changes
+
+| # | Change | Capabilities | Depends on |
+|---|---|---|---|
+| 1 | `bootstrap-solution` | `application-host` | — |
+| 2 | `add-settings-store` | `settings-persistence` | 1 |
+| 3 | `add-file-logging` | `file-logging` | 2 |
+| 4 | `add-audio-pipeline` | `audio-capture`, `audio-encoding` | 1 |
+| 5 | `add-gemini-transcription` | `gemini-transcription` | 2, 4 |
+| 6 | `add-global-hotkey` | `global-hotkey` | 1, 2 |
+| 7 | `add-text-output` | `text-output` | 1 |
+| 8 | `add-dictation-pipeline` | `dictation-pipeline` | 4, 5, 6, 7 |
+| 9 | `add-tray-icon` | `tray-icon` | 8 |
+| 10 | `add-settings-window` | `settings-window` | 2, 3, 5, 6, 9 |
+| 11 | `add-system-integration` | `notifications`, `autostart` | 2, 8, 10 |
+| 12 | `add-packaging-ci` | `packaging` | all |
+
+## Artifact status
+
+Changes **1-3** have their full artifact set (`proposal`, `specs`, `design`, `tasks`) and are ready
+for `/opsx:apply`. Changes **4-12** have `proposal.md` only; their `specs`, `design` and `tasks` are
+written when their turn comes.
+
+This is deliberate. The four spikes in change 1 can invalidate design decisions downstream — if
+SharpHook cannot report key release, or miniaudio cannot resample, the affected designs change rather
+than the code. Writing detailed task breakdowns for change 12 today would produce artifacts that are
+stale before anyone reads them.
+
+## Standing decisions
+
+Recorded so they are not repeatedly re-litigated, and not mistaken for oversights:
+
+- **Kept from the reference:** API keys stored in plaintext, and settings living at the
+  home-directory root (`~/.pisum-whisper.json`) rather than the platform config directory.
+- **Fixed relative to the reference:** the user's prior clipboard contents are restored after
+  pasting; captured audio is buffered in mono chunks rather than one unbounded list locked inside
+  the audio callback.
+- **Out of scope:** local Whisper inference, OpenAI as a provider, input device selection,
+  localization, auto-update.
+
+The reference repository is the behavioural specification — wire formats, the recording state machine
+and its timing constants, the settings schema, and the error taxonomy all come from it. It is not a
+.NET project, so nothing is copied; it is read and re-expressed.

--- a/openspec/changes/add-audio-pipeline/.openspec.yaml
+++ b/openspec/changes/add-audio-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-audio-pipeline/proposal.md
+++ b/openspec/changes/add-audio-pipeline/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The product's input is the user's voice. Nothing can be transcribed until audio can be captured from
+the default microphone and encoded into something Gemini accepts.
+
+## What Changes
+
+- Add `IAudioCapture` with a miniaudio implementation over `SoundFlow.Backends.MiniAudio`.
+- **Request 48 kHz mono f32 from the capture device** and let miniaudio convert from whatever the
+  device natively runs at. 48 kHz is already a native Opus rate, so this deletes the reference's
+  entire sinc-resampling stage (256-tap Blackman-Harris2, run twice for two different targets)
+  rather than porting it.
+- Accumulate captured audio as `float[]` chunks in a `Channel<float[]>`, downmixed to mono at
+  capture. The reference grows one shared `Vec<f32>` under a mutex **locked inside the audio
+  callback** — roughly 230 MB for a ten-minute stereo recording, on the realtime thread. This change
+  deliberately does not reproduce that.
+- Add `OggOpusWriter`: Concentus 2.2.2 (`OPUS_APPLICATION_VOIP`, 24 kbps, 20 ms frames, zero-padded
+  tail) plus a hand-rolled Ogg muxer — OpusHead with pre-skip 312, OpusTags, and audio packets whose
+  granule positions are 48 kHz-relative.
+- Add `WavWriter`: 16-bit PCM RIFF.
+- Keep the reference's **bidirectional fallback** — if the preferred format fails to encode, try the
+  other before failing the dictation.
+
+Reference: `W:\github-pisum-transcript\src-tauri\src\audio\{recorder,encoder}.rs`
+(`encoder.rs:137-210` specifies the Ogg/Opus header layout).
+
+## Capabilities
+
+### New Capabilities
+- `audio-capture`: microphone audio is recorded from the system default input device on demand.
+- `audio-encoding`: recorded audio is encoded to Ogg/Opus or WAV for upload.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `bootstrap-solution`, and on spike S2 having confirmed miniaudio can deliver 48 kHz mono.
+Unblocks `add-gemini-transcription`, which needs encoded bytes and a MIME type. If S2 failed, the
+capture implementation changes here but `IAudioCapture` does not.
+
+## Non-goals
+
+- No input device picker — the system default only, matching the reference.
+- No voice activity detection, noise suppression, gain control or level meter.
+- No resampler of our own unless spike S2 proved miniaudio cannot convert.

--- a/openspec/changes/add-dictation-pipeline/.openspec.yaml
+++ b/openspec/changes/add-dictation-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-dictation-pipeline/proposal.md
+++ b/openspec/changes/add-dictation-pipeline/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Capture, encoding, transcription, hotkey and output all exist by now, but nothing connects them. This
+change adds the state machine that turns a keypress into pasted text, and it is where every timing
+rule and concurrency guard lives. **This is the change that first makes the product work end to end.**
+
+## What Changes
+
+- Add `DictationOrchestrator`, a singleton reproducing the reference's recording state machine.
+- Two recording modes:
+  - `holdToRecord` — key down starts, key up stops and transcribes.
+  - `toggle` — key down starts or stops; key up ignored.
+- Timing rules carried over deliberately, each of which fixes a real failure:
+  - **50 ms minimum recording.** Shorter presses are discarded silently, with no notification. An
+    accidental brush of the hotkey should do nothing at all, not raise an error.
+  - **200 ms toggle debounce.** Without it, keyboard auto-repeat toggles recording on and off rapidly.
+  - **50 ms delay** between setting the clipboard and sending the paste keystroke, so the target
+    application observes the new contents.
+- Concurrency guards: already recording, return silently; transcription in flight, report
+  "Transcription In Progress" rather than starting a second overlapping pipeline.
+- Max-duration watchdog built on a `CancellationTokenSource` and `Task.Delay`, cancelled when
+  recording ends normally. The reference spawns a thread that sleeps the entire duration on every
+  recording, leaking one per dictation.
+- Wrap the pipeline in `try`/`catch`, mapping `AppException.Category` to user-facing messages. The
+  reference's `catch_unwind` guard is dead code in its release profile, which aborts on panic.
+
+Reference: `W:\github-pisum-transcript\src-tauri\src\hotkey\manager.rs`, the 515-line core.
+
+## Capabilities
+
+### New Capabilities
+- `dictation-pipeline`: holding or toggling the hotkey records speech and delivers the transcript to the cursor.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `add-audio-pipeline`, `add-gemini-transcription`, `add-global-hotkey` and
+`add-text-output`. Exposes a recording-state signal that `add-tray-icon` consumes. Everything after
+this point is presentation and packaging around a working core.
+
+## Non-goals
+
+- No visual recording indicator — the tray icon is the next change.
+- No notifications yet. Call sites are identified here; the implementation ships in `add-system-integration`.
+- No transcript editing, preview or confirmation step.

--- a/openspec/changes/add-file-logging/.openspec.yaml
+++ b/openspec/changes/add-file-logging/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-file-logging/design.md
+++ b/openspec/changes/add-file-logging/design.md
@@ -1,0 +1,79 @@
+## Context
+
+This application fails where the user cannot see it. It has no window most of the time, its work
+happens on background threads, and its failure modes — a hook that never fires, a microphone that
+returns silence, a Gemini call that returns 429 — all look identical from outside: nothing happens.
+Without a log on disk, every bug report is "it didn't work".
+
+The reference added file logging as a dedicated PRD late in its life
+(`W:\github-pisum-transcript\docs\PRD-file-logging.md`), which is a reasonable signal that it was
+needed in practice rather than anticipated.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Durable diagnostics on disk, bounded in both size and age.
+- Runtime verbosity change, so a user can reproduce a problem at `debug` without restarting.
+- A logging abstraction registered early enough that every later change uses it natively.
+
+**Non-Goals:**
+- The Logging settings tab, which ships with `add-settings-window`.
+- The "Open Log Folder" button; this change exposes the path, the button is UI.
+- Remote log shipping, crash reporting or telemetry.
+
+## Decisions
+
+**Serilog with `Serilog.Sinks.File`, behind `Microsoft.Extensions.Logging`.** Consumers depend on
+`ILogger<T>`, not on Serilog, so the sink is replaceable. Serilog is chosen for one specific reason:
+`LoggingLevelSwitch` gives runtime level changes, which is a hard requirement here and awkward with
+the built-in providers.
+
+**Both size-based rolling and age-based deletion.** These are not redundant. Rolling by size caps a
+single busy session but never removes a small file from six months ago; age-based deletion removes
+stale files but does nothing about one runaway session. The reference implements both and this
+follows it.
+*Alternative rejected:* daily rolling with a retained-file count. It expresses "keep N days" more
+directly but does not bound a single day's file, and a debug-level session can produce a very large
+one.
+
+**`LoggingLevelSwitch` held by the logging component and mutated on settings change.** This is the
+direct analogue of the reference's reloadable `EnvFilter`, and it is the whole point of the feature:
+a level that requires a restart to change is useless for capturing an intermittent problem, because
+restarting destroys the state that caused it.
+
+**Age sweep runs once at startup, not on a timer.** The reference does the same. A background timer
+adds a lifecycle to manage for a housekeeping task with no deadline; a desktop utility restarts often
+enough.
+
+**Logging initialises after settings load, not before.** It needs `LoggingConfig` for the path, size
+and retention. Anything that must be reported before that point goes to the console under `#if DEBUG`.
+This creates a genuine ordering constraint on the composition root, and a small window at startup
+where failures are not logged to file — accepted, because the alternative is a second bootstrap
+configuration that would then have to be reconciled with the real one.
+
+**Failure to set up file logging must not prevent startup.** A locked or unwritable log directory is
+an inconvenience; refusing to launch a dictation tool over it is not proportionate.
+
+**Console sink only under `#if DEBUG`.** The release build is a windowless tray process with nowhere
+for console output to go.
+
+## Risks / Trade-offs
+
+- **The startup window before logging exists is unlogged.** → Small and bounded: only settings
+  resolution happens first. Accepted rather than adding a second logger configuration.
+
+- **Serilog's own failures are silent by design.** → Enable `SelfLog` to the debug console in debug
+  builds so a misconfigured sink is visible during development.
+
+- **Logs may contain sensitive text.** Transcripts are user speech and settings contain API keys. →
+  Never log transcript content or API key values; log lengths, categories and outcomes instead. This
+  needs stating now, because every later change writes log statements against this decision.
+
+- **Runtime level changes could be missed if a component caches a logger's enabled state.** → The
+  level switch is evaluated per write by Serilog, so this holds as long as nothing caches
+  `IsEnabled`. Worth a test.
+
+## Open Questions
+
+None. The size, retention and level defaults are inherited from the reference (1 MB, 7 days, `info`)
+and are exposed as settings, so no value needs to be guessed here.

--- a/openspec/changes/add-file-logging/proposal.md
+++ b/openspec/changes/add-file-logging/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+A dictation app fails in places the user cannot see: a hotkey that never fires, a microphone that
+returns silence, a Gemini call that 429s. Without a log on disk, every one of those is an unactionable
+"it didn't work" report.
+
+## What Changes
+
+- Configure Serilog writing to `~/.pisum-whisper/logs/pisum-whisper.log`.
+- Roll on file size using `logMaxFileSizeMb` from settings, retaining at most 10 rotated files.
+- Sweep files older than `logRetentionDays` at startup — size-based rolling alone never removes an
+  old, small file, so both mechanisms are needed.
+- Expose the log level through a `LoggingLevelSwitch` so changing it in settings takes effect
+  immediately, with no restart. This is the direct analogue of the reference's reloadable
+  `EnvFilter`, and it is the point of the feature: a user reproducing a bug can raise the level to
+  `debug` mid-session.
+- Add a console sink under `#if DEBUG` only.
+- Expose the resolved log directory so the settings window can show it and open it later.
+
+Reference: `W:\github-pisum-transcript\src-tauri\src\logging.rs`.
+
+## Capabilities
+
+### New Capabilities
+- `file-logging`: diagnostic output is written to disk, rotated by size, expired by age, and its verbosity is changeable at runtime.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `add-settings-store` for `LoggingConfig`. Every later change logs through the abstraction
+this one registers, so landing it early keeps `ILogger<T>` available throughout rather than
+retrofitted.
+
+## Non-goals
+
+- No Logging settings tab — that ships with `add-settings-window`.
+- No "Open Log Folder" button; the path is exposed here, the button is UI.
+- No remote log shipping, no crash reporting, no telemetry.

--- a/openspec/changes/add-file-logging/specs/file-logging/spec.md
+++ b/openspec/changes/add-file-logging/specs/file-logging/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Diagnostics are written to disk
+The application SHALL write structured log output to a file under
+`~/.pisum-whisper/logs/`, creating the directory if it does not exist.
+
+#### Scenario: First run with no log directory
+- **WHEN** the application starts and the log directory does not exist
+- **THEN** the directory is created and a log file is written
+
+#### Scenario: The log directory cannot be created
+- **WHEN** the log directory cannot be created or written to
+- **THEN** the application continues to run and reports the failure, rather than failing to start
+
+### Requirement: Logs are bounded by size
+The application SHALL roll the log file when it exceeds the configured maximum size, retaining at
+most ten rolled files.
+
+#### Scenario: The log file exceeds the size limit
+- **WHEN** the active log file grows past `logMaxFileSizeMb`
+- **THEN** it is rolled and subsequent output goes to a new file
+
+#### Scenario: More than ten rolled files exist
+- **WHEN** rolling would produce an eleventh retained file
+- **THEN** the oldest rolled file is removed
+
+### Requirement: Logs are bounded by age
+The application SHALL delete log files older than the configured retention period at startup.
+Size-based rolling alone never removes an old, small file, so both bounds are required.
+
+#### Scenario: An expired log file is present at startup
+- **WHEN** the application starts and a log file is older than `logRetentionDays`
+- **THEN** that file is deleted
+
+#### Scenario: A log file is within the retention period
+- **WHEN** the application starts and a log file is newer than `logRetentionDays`
+- **THEN** that file is kept
+
+### Requirement: Verbosity changes without restart
+The application SHALL apply a change to the configured log level immediately, so that a user
+reproducing a problem can raise verbosity mid-session.
+
+#### Scenario: The user raises the log level
+- **WHEN** `logLevel` is changed from `info` to `debug`
+- **THEN** debug output appears in the log file without restarting the application
+
+#### Scenario: The user lowers the log level
+- **WHEN** `logLevel` is changed from `debug` to `warning`
+- **THEN** informational and debug output stops appearing without restarting the application
+
+### Requirement: The log location is discoverable
+The application SHALL expose the resolved log directory so it can be shown to the user and opened.
+
+#### Scenario: The log path is requested
+- **WHEN** the log directory path is requested
+- **THEN** the absolute resolved path is returned, whether or not any log file exists yet

--- a/openspec/changes/add-file-logging/tasks.md
+++ b/openspec/changes/add-file-logging/tasks.md
@@ -1,0 +1,24 @@
+## 1. Sink setup
+
+- [ ] 1.1 Add Serilog and `Serilog.Sinks.File` to central package management and register Serilog behind `Microsoft.Extensions.Logging` in the composition root, after settings load. Verify: run the app and confirm `~/.pisum-whisper/logs/pisum-whisper.log` is created and contains a startup line.
+- [ ] 1.2 Resolve and expose the log directory through a service, creating it if absent. Verify: unit test against a temp home asserts the resolved path and that the directory is created.
+- [ ] 1.3 Make setup failure non-fatal: if the directory cannot be created or written, report and continue. Verify: unit test with an unwritable path asserts no exception escapes and the failure is reported.
+- [ ] 1.4 Enable Serilog `SelfLog` to the debug console under `#if DEBUG` only. Verify: misconfigure a sink temporarily and confirm the diagnostic appears, then revert.
+- [ ] 1.5 Add a console sink under `#if DEBUG` only. Verify: debug build prints to console; release build produces no console output.
+
+## 2. Size and age bounds
+
+- [ ] 2.1 Configure size-based rolling from `logMaxFileSizeMb` with `retainedFileCountLimit` of 10. Verify: integration test sets a 1 KB limit, writes until it rolls, and asserts a second file exists.
+- [ ] 2.2 Assert the retained-file cap. Verify: integration test rolls more than ten times and asserts at most ten rolled files remain.
+- [ ] 2.3 Implement the startup age sweep deleting `*.log*` files older than `logRetentionDays`. Verify: unit test creates files with backdated timestamps either side of the boundary and asserts only the expired ones are deleted.
+
+## 3. Runtime verbosity
+
+- [ ] 3.1 Introduce a `LoggingLevelSwitch` owned by the logging component and use it as the minimum level. Verify: unit test writes at debug with the switch at information and asserts nothing is written.
+- [ ] 3.2 Map the `logLevel` string to a Serilog level, falling back to `information` on an unrecognised value with a warning. Verify: unit tests for each valid value and one invalid value.
+- [ ] 3.3 Subscribe to the settings change event and update the switch. Verify: unit test changes the level through the settings store and asserts output at the new level appears without re-creating the logger.
+- [ ] 3.4 Confirm nothing caches `IsEnabled` across a level change. Verify: unit test raises the level mid-run and asserts a previously suppressed statement now writes.
+
+## 4. Logging conventions
+
+- [ ] 4.1 Document in `CLAUDE.md` that transcript text and API key values must never be logged, and that lengths, categories and outcomes are logged instead. Verify: the rule is written down before any change that handles transcripts is implemented.

--- a/openspec/changes/add-gemini-transcription/.openspec.yaml
+++ b/openspec/changes/add-gemini-transcription/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-gemini-transcription/proposal.md
+++ b/openspec/changes/add-gemini-transcription/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Captured audio has to become text. Gemini is the transcription backend, and a single API key is a
+single point of both failure and quota exhaustion — so the client needs retry and the pool needs
+more than one key.
+
+## What Changes
+
+- Add `ITranscriptionProvider` and `GeminiProvider` over `IHttpClientFactory`:
+  - `POST /v1beta/models/{model}:generateContent`, the active preset as `system_instruction`, audio
+    as base64 `inline_data` with its MIME type, `temperature 0.1`, `maxOutputTokens 8192`.
+  - Default model `gemini-2.5-flash-lite`.
+  - `ListModelsAsync` — `GET /v1beta/models`, keeping entries that support `generateContent` and
+    stripping the `models/` prefix — so the settings window can offer a real dropdown.
+  - `TestConnectionAsync` for the settings button.
+  - Retry 3 times with linear backoff (1 s, 2 s) on 429/503 or a body mentioning `overloaded`,
+    `too many requests` or `rate limit`. Everything else fails immediately rather than burning
+    seconds on an error that will not resolve.
+- Add `GeminiProviderPool`: round-robin start index across *enabled* entries, walking all of them on
+  failure and aggregating into one `"All providers failed: …"` error. Rebuilt whenever settings change.
+- Introduce typed `AppException` with an `ErrorCategory` (`Audio`, `Configuration`, `Network`,
+  `Authentication`, `RateLimit`, `Transcription`, `Output`). The reference decides notification
+  titles by substring-matching error text; categorising at the throw site is the same behaviour
+  without the string sniffing.
+
+Reference: `W:\github-pisum-transcript\src-tauri\src\ai\{gemini,provider,pool}.rs`.
+
+## Capabilities
+
+### New Capabilities
+- `gemini-transcription`: recorded audio is transcribed to text by Google Gemini, across one or more configured API keys.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `add-settings-store` (provider entries, active preset) and `add-audio-pipeline` (encoded
+bytes plus MIME type). Unblocks `add-dictation-pipeline`. `ITranscriptionProvider` is also the seam
+if a second provider is ever wanted.
+
+## Non-goals
+
+- No OpenAI provider.
+- No streaming or partial transcripts — one request, one result.
+- No local/offline inference.
+- No cost tracking or usage metering.

--- a/openspec/changes/add-global-hotkey/.openspec.yaml
+++ b/openspec/changes/add-global-hotkey/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-global-hotkey/proposal.md
+++ b/openspec/changes/add-global-hotkey/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The entire product is driven by one global key binding, and it must report both edges: press starts
+recording, release stops it. This rules out the obvious platform APIs — Win32 `RegisterHotKey` fires
+`WM_HOTKEY` on press only, and Carbon `RegisterEventHotKey` behaves the same. Hold-to-record cannot
+be built on either, so the hotkey layer needs a raw hook rather than a registration API.
+
+## What Changes
+
+- Add `IGlobalHotkeyService` with a SharpHook implementation owning one libuiohook global hook
+  (`WH_KEYBOARD_LL` on Windows, `CGEventTap` on macOS).
+- Because a raw hook reports every key rather than a registered combination, track the modifier mask
+  and match the configured binding ourselves. That is more control than the reference had: the
+  settings window's hotkey recorder can later reuse the same hook in a capture mode instead of
+  depending on browser key events.
+- Add `KeyCodeMap`, a string to `SharpHook.Data.KeyCode` table ported from the reference's key table
+  (letters, digits, F1-F12, arrows, punctuation, numpad) plus modifier aliases
+  (`ctrl`/`control`, `alt`, `shift`, `meta`/`super`/`win`/`cmd`/`command`).
+- Add `ConflictDetector` carrying the reference's system-hotkey table (Ctrl+Alt+Del, Alt+Tab, Alt+F4,
+  Win+L/D/E/R/Tab, Ctrl+Shift+Esc, Cmd+Q/W/Tab, Cmd+Shift+3/4/5, Cmd+Space, Ctrl+Space) with
+  normalised, order-insensitive comparison. It **warns only and never blocks the binding** — same as
+  the reference, because the table is a heuristic and users have legitimate reasons to override it.
+- Default binding: Ctrl+Shift+Space, or Cmd+Shift+Space on macOS.
+
+Reference: `W:\github-pisum-transcript\src-tauri\src\hotkey\` (`manager.rs`, `parse.rs`, `conflict.rs`).
+
+## Capabilities
+
+### New Capabilities
+- `global-hotkey`: a user-configurable key combination is observed system-wide, reporting both press and release.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `bootstrap-solution` (specifically spike S1) and `add-settings-store` for the binding.
+Unblocks `add-dictation-pipeline`. On macOS the hook requires the **Accessibility** permission — the
+same grant the paste simulation needs, so it costs the user nothing extra, but it must be requested
+and handled here rather than assumed.
+
+## Non-goals
+
+- No hotkey recorder UI — that ships with the settings window; this change exposes the capture mode it will use.
+- No per-preset bindings and no multiple simultaneous bindings.
+- No mouse buttons or media keys.

--- a/openspec/changes/add-packaging-ci/.openspec.yaml
+++ b/openspec/changes/add-packaging-ci/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-packaging-ci/proposal.md
+++ b/openspec/changes/add-packaging-ci/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Everything so far runs under `dotnet run`. That is precisely the configuration in which the two
+hardest platform behaviours are least trustworthy: macOS ties Accessibility grants to a binary's code
+signature, so an unsigned or rebuilt-each-time binary re-prompts forever, and Windows toasts need an
+AUMID that only an installed Start-menu shortcut provides. **The app is not verified until it is
+verified from an installed build.**
+
+## What Changes
+
+- Publish profiles: `win-x64` and `osx-arm64`, self-contained, ReadyToRun.
+- Windows: an MSI that installs a Start-menu shortcut **carrying the AUMID**, satisfying the
+  requirement recorded in `add-system-integration`.
+- macOS: assemble a `Pisum Whisper.app` bundle with `Info.plist` declaring `LSUIElement` (menu-bar
+  only), `NSMicrophoneUsageDescription` and `CFBundleIdentifier = net.pisum.whisper`; then codesign
+  with the hardened runtime and entitlements, and notarize.
+- Establish a **stable signing identity for development**, so Accessibility grants survive rebuilds.
+  The reference ships unsigned and strips the quarantine attribute in a postinstall script; that
+  papers over the symptom and leaves developers re-granting permission on every build.
+- GitHub Actions matrix over `windows-latest` and `macos-latest`, producing both artifacts and
+  running the unit test suite — the reference's CI runs no tests at all.
+- Document the required prerequisites and permissions in `README.md`.
+
+Reference: `.github/workflows/`, `scripts/create-macos-pkg.sh` and `packages/` in the reference repo.
+Note that the repository remote is GitHub, so `gh` is the CLI, not `glab`.
+
+## Capabilities
+
+### New Capabilities
+- `packaging`: the application is built, signed and distributed as an installable artifact for Windows x64 and macOS Apple Silicon.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on every preceding change. Verification here is the real acceptance test for the whole
+sequence: install on clean machines and confirm the hotkey, microphone and paste all work from the
+installed build, and that the permission prompts appear once and stick.
+
+## Non-goals
+
+- No Chocolatey package and no Homebrew cask. The reference has both; they are a distribution
+  decision that can follow once the installers themselves are proven.
+- No auto-update mechanism.
+- No Linux target, and no win-arm64 or osx-x64.

--- a/openspec/changes/add-settings-store/.openspec.yaml
+++ b/openspec/changes/add-settings-store/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-settings-store/design.md
+++ b/openspec/changes/add-settings-store/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Every subsystem in the application reads configuration: the hotkey binding, the Gemini API keys and
+model, the active preset's system prompt, the log level, the recording mode and its duration cap.
+Nothing else can be built until one component owns loading, defaulting, validating and persisting it.
+
+The reference (`W:\github-pisum-transcript\src-tauri\src\config\`) has been running this schema in
+production through several releases without a version field or a migration step. That is worth
+understanding rather than copying blindly: it works because *every* field carries a serde default, so
+any older file is a valid newer file. That property is the actual design, and it has to be preserved
+deliberately.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One owner of settings state, with an in-memory cache and change notification.
+- Forward and backward compatibility with no migration machinery.
+- Self-repair of the two states the reference found worth fixing: missing built-in presets, and a
+  dangling `activePresetId`.
+- A settled schema shape, since changing it later means touching every downstream change.
+
+**Non-Goals:**
+- Any settings UI.
+- Encryption of API keys, or moving off the home directory. Both are deliberate parity choices,
+  recorded below so they are not mistaken for oversights.
+
+## Decisions
+
+**Defaults on every property, and no schema version field.** A settings file that omits half its
+properties must load. This makes adding a property a non-event: old files simply pick up its default.
+*Alternative rejected:* a `schemaVersion` field with migration steps. It buys nothing until a
+property is renamed or changes meaning, and neither has happened across the reference's lifetime.
+
+**`System.Text.Json` with a source-generated `JsonSerializerContext`.** Avoids reflection-based
+serialization, keeps trimming and AOT viable later, and gives compile-time errors on unsupported
+shapes.
+
+**camelCase naming to match the reference's on-disk format.** The file is user-editable and users may
+already have one; there is no reason to churn the format.
+
+**Settings shape is the reference's minus three fields.** `transcriptionMode` and `whisperConfig` go
+with local inference, and `providerType` goes because Gemini is the only provider type. Adding a
+single-valued discriminator "in case OpenAI returns" is speculative; `ITranscriptionProvider` is
+already the seam that would carry it.
+
+**Repair on load, and re-persist the repair.** When `activePresetId` dangles, fixing it in memory
+only means repeating the repair on every launch and leaving a file that still looks broken. Write it
+back.
+
+**Built-in presets merge by id, never overwrite.** A user who edits a built-in prompt keeps their
+edit; a user missing a newly added built-in gains it. This is why merge is by id rather than by
+replacing the built-in set wholesale.
+
+**Copy both built-in preset prompts verbatim.** These long German strings are not boilerplate — they
+*are* the product's cleanup behaviour, instructing Gemini to turn dictation into fluent written prose
+and strip filler words. Paraphrasing them changes what the product does.
+
+**`SettingsStore` is a singleton with a change event, not a static.** The reference uses a global
+`RwLock<AppSettings>`; the equivalent here is a DI singleton, which is testable and disposes cleanly.
+
+**Deliberate parity: API keys stay in plaintext, and the file stays at the home-directory root.**
+Both were considered and kept, so that this change is a faithful re-creation rather than a partial
+redesign. The upgrade path — DPAPI on Windows, Keychain on macOS, and `%APPDATA%` /
+`~/Library/Application Support` — remains open and is not blocked by anything decided here.
+
+## Risks / Trade-offs
+
+- **A corrupt settings file blocks startup.** → The reference surfaces the parse error and refuses to
+  continue rather than silently discarding user configuration, which would throw away API keys. Keep
+  that behaviour; the message must name the file path so the user can fix or delete it.
+
+- **Repair-on-load can mask a bug.** If `activePresetId` dangles because of a defect elsewhere, silent
+  repair hides it. → Log the repair at warning level with the offending id, as the reference does.
+
+- **Plaintext API keys.** → Accepted, deliberately, for parity. Worth revisiting as its own change;
+  the store is the only component that would need to change.
+
+- **Settling the schema now means downstream churn if it moves.** → That is precisely why this change
+  is early and small: five downstream changes read it, and the cost of getting it wrong grows with
+  each one.
+
+## Open Questions
+
+- Should the store debounce writes? The settings UI saves on every change, which for a text field
+  could mean a write per keystroke. Deferred to `add-settings-window`, where the input behaviour is
+  known; the store's API does not need to change to add it.

--- a/openspec/changes/add-settings-store/proposal.md
+++ b/openspec/changes/add-settings-store/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Every other subsystem reads configuration: the hotkey binding, the Gemini keys and model, the active
+preset's system prompt, the log level, the recording mode. Nothing else can be built until there is
+one place that owns loading, defaulting, validating and persisting it.
+
+## What Changes
+
+- Add `AppSettings` and its DTOs (`Preset`, `ProviderConfig`, `HotkeyBinding`, `LoggingConfig`) with
+  camelCase JSON via a source-generated `JsonSerializerContext`.
+- **Every property gets a default.** This is what lets an older or partial file load without error,
+  and it is the reason the reference never breaks on upgrade — it is a requirement, not a style choice.
+- Add `SettingsStore` reading and writing `~/.pisum-whisper.json`, with an in-memory cache and a
+  change notification other services subscribe to.
+- Port two load-time repair behaviours exactly from the reference:
+  - merge in any **missing built-in presets**, so a new built-in appears for existing users;
+  - if `activePresetId` resolves to no preset, fall back to the first built-in **and re-persist**.
+- Detect first launch (settings file absent) and expose it, so the welcome flow can hang off it later.
+- Copy both built-in preset prompts (`de-transcribe`, `en-transcribe`) verbatim. These German prompt
+  strings *are* the product's cleanup behaviour — they instruct Gemini to turn dictation into fluent
+  written prose and strip filler words.
+
+Settings shape is the reference's minus `transcriptionMode`, `whisperConfig` and `providerType`
+(Gemini is now the only provider type).
+
+Reference: `W:\github-pisum-transcript\src-tauri\src\config\{schema,manager,presets}.rs`.
+
+## Capabilities
+
+### New Capabilities
+- `settings-persistence`: application settings load, validate, repair and persist across runs.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `bootstrap-solution`. Unblocks `add-file-logging`, `add-global-hotkey`,
+`add-gemini-transcription`, and the settings window. Changing the schema after downstream changes
+land means touching all of them, so settle the shape here.
+
+## Non-goals
+
+- No settings UI — that is `add-settings-window`.
+- No encryption of API keys, and no move to the platform config directory. Both are deliberate
+  parity choices with the reference, recorded so they are not mistaken for oversights.

--- a/openspec/changes/add-settings-store/specs/settings-persistence/spec.md
+++ b/openspec/changes/add-settings-store/specs/settings-persistence/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Settings persist across runs
+The application SHALL store its settings as JSON at `~/.pisum-whisper.json` and reload them on
+startup.
+
+#### Scenario: Settings survive a restart
+- **WHEN** a setting is changed and the application is restarted
+- **THEN** the changed value is in effect after restart
+
+#### Scenario: Settings are written in camelCase
+- **WHEN** settings are written to disk
+- **THEN** every property name in the file is camelCase
+
+### Requirement: Every setting has a default
+Every property SHALL have a default value, so that a settings file missing any property loads
+successfully rather than failing.
+
+#### Scenario: A property is absent from the file
+- **WHEN** a settings file omits one or more properties
+- **THEN** the missing properties take their default values and no error is raised
+
+#### Scenario: The settings file does not exist
+- **WHEN** the application starts with no settings file present
+- **THEN** a file containing the complete defaults is written
+- **AND** the run is reported as a first launch
+
+#### Scenario: The settings file is unreadable
+- **WHEN** the settings file exists but contains invalid JSON
+- **THEN** the failure is surfaced with the underlying parse error rather than silently overwritten
+
+### Requirement: Built-in presets are restored
+The application SHALL merge any missing built-in presets into the loaded settings, so a built-in
+preset added in a later version appears for existing users.
+
+#### Scenario: A built-in preset is missing from the file
+- **WHEN** settings are loaded and a built-in preset id is not present
+- **THEN** that built-in preset is added to the preset list
+
+#### Scenario: A built-in preset was edited by the user
+- **WHEN** settings are loaded and a built-in preset id is present with user-modified content
+- **THEN** the user's version is kept and not overwritten
+
+### Requirement: The active preset always resolves
+The application SHALL guarantee that `activePresetId` refers to an existing preset, repairing and
+re-persisting the settings when it does not.
+
+#### Scenario: The active preset id refers to nothing
+- **WHEN** settings are loaded and `activePresetId` matches no preset
+- **THEN** the first built-in preset becomes active
+- **AND** the corrected settings are written back to disk
+
+#### Scenario: The active preset is deleted
+- **WHEN** the user deletes the preset that is currently active
+- **THEN** the first remaining preset becomes active
+
+### Requirement: Built-in presets cannot be deleted
+The application SHALL refuse to delete a preset marked as built-in.
+
+#### Scenario: Deleting a built-in preset
+- **WHEN** deletion of a built-in preset is requested
+- **THEN** the request is rejected with an explanatory error and the preset list is unchanged
+
+### Requirement: Settings changes are observable
+The application SHALL notify interested components when settings change, so they can re-apply
+without a restart.
+
+#### Scenario: A setting is saved
+- **WHEN** settings are saved
+- **THEN** the in-memory cache is updated and subscribers are notified with the new values

--- a/openspec/changes/add-settings-store/tasks.md
+++ b/openspec/changes/add-settings-store/tasks.md
@@ -1,0 +1,27 @@
+## 1. Schema
+
+- [ ] 1.1 Add `AppSettings` with a default for every property, plus `HotkeyBinding` (modifiers, key) defaulting to Ctrl+Shift+Space, or Cmd+Shift+Space on macOS. Verify: unit test asserts `new AppSettings()` has every documented default.
+- [ ] 1.2 Add `Preset` (id, name, systemPrompt, isBuiltin) and `ProviderConfig` (id, apiKey, model, enabled). Verify: unit test round-trips each through JSON unchanged.
+- [ ] 1.3 Add `LoggingConfig` (logLevel `info`, logMaxFileSizeMb 1, logRetentionDays 7). Verify: covered by the defaults test in 1.1.
+- [ ] 1.4 Add a source-generated `JsonSerializerContext` with camelCase naming. Verify: unit test asserts serialized output contains `startWithSystem` and not `StartWithSystem`.
+- [ ] 1.5 Copy both built-in preset prompts verbatim from the reference's `config/presets.rs` into `BuiltinPresets`. Verify: unit test asserts ids `de-transcribe` and `en-transcribe` exist, are marked built-in, and have non-empty prompts.
+
+## 2. Load, repair and save
+
+- [ ] 2.1 Add `SettingsStore` resolving `~/.pisum-whisper.json` and implement `Load`. Verify: unit test against a temp home directory loads a hand-written file.
+- [ ] 2.2 Implement first-launch detection: when no file exists, write full defaults and report it. Verify: unit test asserts the file is created, defaults are written, and the first-launch flag is true only on that run.
+- [ ] 2.3 Implement partial-file tolerance. Verify: unit test loads a file containing only `{"startWithSystem": false}` and asserts every other property took its default.
+- [ ] 2.4 Implement built-in preset merge by id. Verify: two unit tests — a file with no presets gains both built-ins; a file with an edited `de-transcribe` keeps the user's text.
+- [ ] 2.5 Implement `activePresetId` repair with write-back and a warning log. Verify: unit test loads a file with a dangling id, asserts the first built-in is active, and asserts the file on disk was corrected.
+- [ ] 2.6 Implement `Save`, updating the in-memory cache and raising a change event. Verify: unit test subscribes, saves, and asserts the subscriber received the new values.
+- [ ] 2.7 Surface a parse failure with the file path and the underlying error, without overwriting the file. Verify: unit test writes invalid JSON, asserts the exception names the path, and asserts the file is byte-identical afterwards.
+
+## 3. Preset operations
+
+- [ ] 3.1 Implement add, update and delete for presets. Verify: unit tests for each.
+- [ ] 3.2 Reject deletion of a built-in preset. Verify: unit test asserts the error and that the list is unchanged.
+- [ ] 3.3 Reassign the active preset when the active one is deleted. Verify: unit test asserts the first remaining preset becomes active.
+
+## 4. Wiring
+
+- [ ] 4.1 Register `SettingsStore` as a singleton in the composition root and load settings during startup. Verify: run the app and confirm a log line reports the settings path and whether this was a first launch.

--- a/openspec/changes/add-settings-window/.openspec.yaml
+++ b/openspec/changes/add-settings-window/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-settings-window/proposal.md
+++ b/openspec/changes/add-settings-window/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+Every setting the app reads is, so far, only editable by hand-writing JSON. The user needs a way to
+add a Gemini API key, pick a model, edit preset prompts, change the hotkey and adjust logging —
+without which the product is not usable by anyone but its author.
+
+## What Changes
+
+- Add a single Avalonia settings window: 700x540, minimum 540x400, resizable, not maximizable,
+  centred, **created hidden**, and **closing hides it rather than quitting** the app.
+- Six tabs, ported from the reference's Svelte components:
+  - **Providers** — add and remove Gemini entries; masked API key with a reveal toggle; model
+    dropdown populated from `ListModelsAsync` with a Refresh button; enable toggle; Test Connection
+    with an inline result.
+  - **Presets** — CRUD with Built-in and Active badges; built-in presets cannot be deleted; inline edit.
+  - **Hotkey** — current binding plus Change, which switches to a live recorder (at least one
+    modifier required, Escape cancels) reusing the global hook's capture mode; conflict warning banner.
+  - **Audio** — Opus or WAV.
+  - **Logging** — level, max file size (1-100 MB), retention (1-365 days), log path, Open Log Folder.
+  - **General** — start with system, show notifications, recording mode, max duration (10-3600 s).
+- Keep the reference's **save-on-change** model. There is no OK, Cancel or Apply: every edit persists
+  immediately and re-applies live — rebuild the provider pool, hot-swap the log level, re-register
+  the hotkey, refresh the tray tooltip. A tray utility the user visits rarely should never lose an
+  edit to a forgotten Apply button.
+- MVVM with `CommunityToolkit.Mvvm` source generators.
+
+The reference reaches its backend through 20 IPC commands; here these are direct service calls, so
+no IPC layer is needed.
+
+Reference: `W:\github-pisum-transcript\src\components\` and the window block of `tauri.conf.json`.
+
+## Capabilities
+
+### New Capabilities
+- `settings-window`: all application settings are viewable and editable in a window reachable from the tray, applying immediately.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `add-settings-store`, `add-file-logging`, `add-gemini-transcription`, `add-global-hotkey`
+and `add-tray-icon`. This is the largest UI change in the sequence and the last one before the app is
+usable by someone other than its author.
+
+## Non-goals
+
+- No dark theme. The reference's settings window is light-only and this is not the change to fix that.
+- No localization; strings stay hardcoded English.
+- No input device picker.
+- No onboarding wizard or About dialog.

--- a/openspec/changes/add-system-integration/.openspec.yaml
+++ b/openspec/changes/add-system-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-system-integration/proposal.md
+++ b/openspec/changes/add-system-integration/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Two gaps remain between a working app and one that behaves like an installed desktop utility. The
+pipeline currently fails silently — a 401, a missing microphone or an exhausted quota produces
+nothing the user can see, because the window is usually hidden. And a dictation tool that has to be
+launched by hand every morning will not be used.
+
+## What Changes
+
+- Add `INotificationService`:
+  - Windows — toast via `CommunityToolkit.WinUI.Notifications`, which requires an AUMID registered by
+    a Start-menu shortcut. That constraint is recorded here and satisfied by `add-packaging-ci`.
+  - macOS — `osascript -e 'display notification ... with title ...'`, which needs no bundle signing.
+    This is exactly what the reference's own installer script already does.
+- Port the reference's notification policy precisely, because the distinction matters: **errors are
+  forced and ignore the user's preference**, while status messages respect the
+  `showTrayNotifications` toggle. Someone who silences chatter still needs to be told their API key
+  is rejected.
+- Wire the notification call sites left marked in `add-dictation-pipeline`, mapping
+  `AppException.Category` to titles: Recording Error, Configuration Error, Network Error,
+  Authentication Error, Rate Limit Error, Transcription Error, Output Error.
+- Add `IAutostartService`: on Windows a value under
+  `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`; on macOS a LaunchAgent plist at
+  `~/Library/LaunchAgents/net.pisum.whisper.plist`.
+- Add `IShellService` to open the log folder (`explorer.exe` / `open`), completing the Logging tab.
+- Add the first-launch flow, hanging off the detection added in `add-settings-store`: enable
+  autostart when `startWithSystem` is set, show a welcome notification, and open the settings window
+  so a new user is pointed at the API key field rather than left with a silent tray icon.
+
+Reference: `tray.rs` for notifications, `tauri-plugin-autostart` for startup, and the `setup()` block
+of `lib.rs` for the first-launch sequence.
+
+## Capabilities
+
+### New Capabilities
+- `notifications`: the user is informed of errors and significant status changes through the operating system's notification service.
+- `autostart`: the application can register itself to launch at login and be unregistered again.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `add-settings-store`, `add-dictation-pipeline` and `add-settings-window`. Places a hard
+requirement on `add-packaging-ci`: without the Start-menu shortcut carrying the AUMID, Windows toasts
+do not appear from an installed build.
+
+## Non-goals
+
+- No in-app notification centre or history.
+- No notification actions, buttons or transcript previews in the toast.
+- No `SMAppService` on macOS 13+; the LaunchAgent plist matches the reference and works further back.

--- a/openspec/changes/add-text-output/.openspec.yaml
+++ b/openspec/changes/add-text-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-text-output/proposal.md
+++ b/openspec/changes/add-text-output/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+A transcript that stays inside the app is useless. The result has to arrive at the cursor in whatever
+application the user was already typing in — which means the clipboard plus a synthetic paste, since
+no cross-application API exists to insert text directly.
+
+## What Changes
+
+- Add `IClipboardService` and `IPasteService`.
+- Clipboard access through Avalonia's `IClipboard`, marshalled onto the UI thread.
+- Paste through SharpHook's `EventSimulator`: hold Ctrl (Cmd on macOS), click V, release.
+- **Save and restore the previous clipboard contents.** The reference overwrites the clipboard on
+  every dictation and never puts it back, silently destroying whatever the user had copied. Read the
+  previous text, set the transcript, paste, wait, then restore — best-effort, so a failed read never
+  blocks the dictation itself.
+- Preserve the reference's graceful degradation: if the paste keystroke fails, the transcript is
+  already on the clipboard, so report "Text was copied to clipboard but paste simulation failed.
+  Use Ctrl+V to paste manually" rather than losing the result outright.
+
+Reference: `W:\github-pisum-transcript\src-tauri\src\output\` (`clipboard.rs`, `paste.rs`).
+
+## Capabilities
+
+### New Capabilities
+- `text-output`: transcribed text is delivered to the active application at the cursor position, without discarding the user's existing clipboard contents.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `bootstrap-solution` (spike S1 covers `EventSimulator`). Unblocks
+`add-dictation-pipeline`. On macOS the paste needs the **Accessibility** permission. On Windows,
+`SendInput` cannot reach an elevated window from a non-elevated process — that case degrades to the
+clipboard fallback message and is expected behaviour, not a defect.
+
+## Non-goals
+
+- No per-application special-casing and no UI Automation text insertion.
+- No transcript history and no re-paste of an earlier result.
+- No rich text, formatting or images — plain text only.

--- a/openspec/changes/add-tray-icon/.openspec.yaml
+++ b/openspec/changes/add-tray-icon/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/add-tray-icon/proposal.md
+++ b/openspec/changes/add-tray-icon/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Once dictation works the app is invisible: no window, no dock icon, no taskbar entry. The user needs
+to know it is running, whether it is currently recording, and how to reach settings or quit. In the
+reference the tray icon is the *only* recording indicator — there is no HUD and no sound.
+
+## What Changes
+
+- Add an Avalonia `TrayIcon` with a `NativeMenu`: Settings, separator, Quit.
+- Two icon states, idle and recording, driven by the orchestrator's recording signal. Those updates
+  arrive on background threads, so marshal them through `Dispatcher.UIThread.Post`.
+- Dynamic tooltip, `"Pisum Whisper - {active preset}"`, refreshed when the active preset changes.
+- Theme handling through `TopLevel.PlatformSettings.GetColorValues()` and its `ColorValuesChanged`
+  event to select a light or dark icon variant. One mechanism covers **both** platforms, replacing
+  the reference's direct Windows registry read of `AppsUseLightTheme`. On macOS, prefer a template
+  image and let AppKit invert it if Avalonia exposes that (spike S3).
+- Confirm the application runs correctly with no window ever shown.
+
+Reference: `W:\github-pisum-transcript\src-tauri\src\tray.rs`.
+
+## Capabilities
+
+### New Capabilities
+- `tray-icon`: the running application is represented in the system tray or menu bar, showing recording state and offering Settings and Quit.
+
+### Modified Capabilities
+_None._
+
+## Impact
+
+Depends on `add-dictation-pipeline` for the recording-state signal, and on spike S3. Unblocks
+`add-settings-window`, which the Settings menu item opens. Note that macOS `NSStatusItem` does not
+present tooltips the way Windows does; if S3 confirms this, the active preset name needs another
+home in the menu itself.
+
+## Non-goals
+
+- No settings window yet. The Settings menu item may be a stub until the next change.
+- No recording HUD, overlay, waveform or audible cue.
+- No transcript history in the menu.

--- a/openspec/changes/bootstrap-solution/.openspec.yaml
+++ b/openspec/changes/bootstrap-solution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/bootstrap-solution/design.md
+++ b/openspec/changes/bootstrap-solution/design.md
@@ -1,0 +1,96 @@
+## Context
+
+The repository holds `Pisum.Whisper.slnx` with no projects, a `global.json` pinning SDK 10.0.400, and
+OpenSpec tooling. There is nothing to build.
+
+The product is a re-creation of `W:\github-pisum-transcript`, a Tauri 2 (Rust) + Svelte 5 application.
+That reference is the behavioural specification, but none of its code transfers: the port replaces
+Rust crates with .NET libraries across the board. Three of those replacements carry behaviour that
+cannot be assumed, and the whole architecture rests on them:
+
+- a global keyboard hook that reports key **release**, not just press;
+- microphone capture that works identically on WASAPI and CoreAudio;
+- a menu-bar icon on macOS driven from a cross-platform UI toolkit.
+
+Building the solution skeleton is cheap. Discovering in change 8 that one of these does not work is
+not. This change therefore does both: it lays down the skeleton and proves the stack.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A solution that builds cleanly on both win-x64 and osx-arm64 from one checkout.
+- A composition root that fails fast on a bad registration.
+- A process that is menu-bar-only from the very first run, so the presentation model is never retrofitted.
+- Binding evidence for or against SharpHook, SoundFlow, Avalonia's tray, and Concentus.
+
+**Non-Goals:**
+- Any dictation behaviour: no hotkey handling, audio, Gemini calls or output.
+- A settings window; the tray menu may be a stub.
+- Packaging, signing or installers.
+
+## Decisions
+
+**Single `net10.0` target framework for every project, including the platform-specific one.**
+Everything OS-specific in this app is P/Invoke or `Process.Start`; nothing needs WinForms, WPF or
+AppKit bindings, because Avalonia supplies the tray icon. Runtime `OperatingSystem.IsWindows()`
+checks plus `[SupportedOSPlatform]` attributes are sufficient.
+*Alternative rejected:* `net10.0-windows` and `net10.0-macos` targets with RID-conditional project
+references. That splits the build graph, makes the solution fail to load on the other platform, and
+buys nothing here.
+
+**One `Pisum.Whisper.Platform` project rather than one per OS.** The genuinely platform-specific
+surface is small — autostart, notifications, opening a folder, a macOS permission check. Two projects
+for that is more ceremony than code.
+*Alternative rejected:* `Platform.Windows` + `Platform.MacOS`, which would force conditional
+references in the app project.
+
+**Central package management** via `Directory.Packages.props`. Four projects sharing Avalonia,
+Serilog and the test stack will drift otherwise.
+
+**Avalonia configured menu-bar-only from the start**, through
+`MacOSPlatformOptions { ShowInDock = false }`. The reference achieves this with an objc2 call to
+`NSApplication.setActivationPolicy(Accessory)`; Avalonia exposes it directly, so no interop is needed.
+
+**Warnings as errors, nullable enabled.** Cheap at four empty projects, expensive to introduce at
+thirty populated ones.
+
+**Spikes are throwaway and are not merged.** Their output is a decision recorded in this change, not
+code. Writing them as production abstractions invites keeping a design that the spike disproved.
+
+**Spikes gate the change.** The skeleton may land first, but this change is not complete until all
+four have a recorded outcome, because later proposals are written against the stack they prove.
+
+## Risks / Trade-offs
+
+- **SharpHook does not deliver reliable key-release, or its macOS run loop conflicts with Avalonia's.**
+  → This is the highest-severity risk in the project: hold-to-record cannot be built on
+  `RegisterHotKey` or `RegisterEventHotKey`, which are press-only. Mitigation: run S1 first, before
+  any other work. Fallback is hand-written `WH_KEYBOARD_LL` and `CGEventTap` interop, which is
+  significant effort and must be discovered now rather than in change 8.
+
+- **SoundFlow cannot open a capture device at 48 kHz mono, or does not resample from the device rate.**
+  → The design deletes the reference's entire sinc-resampling stage on the assumption that miniaudio
+  converts. If it does not, `NAudio.Core`'s managed `WdlResampler` is added behind the same
+  `IAudioCapture` interface. Contained, but must be known before `add-audio-pipeline` is designed.
+
+- **SoundFlow is a large dependency for one job** — it also carries MIDI, synthesis, editing and
+  steganography. → Accepted for now; the alternative is PortAudioSharp2 with native assets to ship
+  per RID, or hand-written CoreAudio interop. Revisit only if it causes packaging problems.
+
+- **Avalonia 12.1 is a recent major line.** → It is a stable release with a real `net10.0` target.
+  One known wrinkle: DevTools moved out of `Avalonia.Diagnostics`, which stops at 11.3.20. Use
+  `ProDiagnostics` 12.1.x or go without. Avalonia 11.3 remains a low-friction fallback if 12.1
+  causes trouble, since the API surface used here is small.
+
+- **macOS Accessibility grants are bound to the code signature**, so an unsigned binary re-prompts on
+  every rebuild and makes S1 painful to iterate on. → Establish a stable development signing identity
+  during this change rather than deferring it to packaging.
+
+## Open Questions
+
+- Does Avalonia's `TrayIcon` expose NSImage template flagging, or must light and dark variants be
+  shipped and selected manually? S3 answers this and `add-tray-icon` depends on the answer.
+- Does SharpHook's global hook require the main thread on macOS, and does that co-exist with
+  Avalonia's run loop? S1 answers this.
+- Is `Concentus.Oggfile` usable with Concentus 2.x, or is a hand-rolled Ogg muxer required? The plan
+  assumes hand-rolled; S4 confirms.

--- a/openspec/changes/bootstrap-solution/proposal.md
+++ b/openspec/changes/bootstrap-solution/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+The repository is an empty scaffold: `Pisum.Whisper.slnx` contains no projects, so nothing can be
+built, run or tested yet. Separately, three third-party libraries carry the riskiest behaviour in the
+whole product — global key **release** events, cross-platform microphone capture, and a macOS
+menu-bar icon. If any of them does not deliver, the architecture changes rather than the code. Both
+problems are cheapest to solve now, before anything is built on top.
+
+## What Changes
+
+- Add `Directory.Build.props` (net10.0, nullable, implicit usings, warnings as errors) and
+  `Directory.Packages.props` (central package management).
+- Add four projects to `Pisum.Whisper.slnx`: `Core`, `Platform`, `App`, `Core.Tests`.
+- Stand up the composition root: generic host + `Microsoft.Extensions.DependencyInjection`, and an
+  Avalonia `AppBuilder` configured with `MacOSPlatformOptions { ShowInDock = false }` so the app is
+  menu-bar-only from the first run.
+- Run four de-risking spikes on **both** win-x64 and osx-arm64 and record the outcome:
+  - **S1 SharpHook** — key down *and* up globally; threading and macOS run-loop requirements;
+    `EventSimulator` producing a paste target apps accept.
+  - **S2 SoundFlow** — open a capture device at 48 kHz mono f32; does miniaudio convert from the
+    device's native rate?
+  - **S3 Avalonia 12.1 tray** — runtime icon swap, tooltip on `NSStatusItem`, template images.
+  - **S4 Concentus + Ogg** — encode and mux a file that plays back.
+- Replace the placeholder "Status" section in `CLAUDE.md` with real build/test commands.
+
+## Capabilities
+
+### New Capabilities
+- `application-host`: the app starts as a tray-only process, resolves its services from a container, and shuts down cleanly.
+
+### Modified Capabilities
+_None — this is the first change._
+
+## Impact
+
+Everything downstream depends on this. Spike outcomes are binding: a failed S1 replaces SharpHook
+with hand-written `WH_KEYBOARD_LL` + `CGEventTap` interop; a failed S2 replaces SoundFlow with
+PortAudioSharp2 or a NAudio/CoreAudio split. Later proposals are written against the stack this
+change proves, so they must not be finalised until it lands.
+
+## Non-goals
+
+- No dictation behaviour, no hotkey handling, no audio, no Gemini calls.
+- No settings window — the tray menu can be a stub.
+- No packaging or installers.

--- a/openspec/changes/bootstrap-solution/specs/application-host/spec.md
+++ b/openspec/changes/bootstrap-solution/specs/application-host/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Menu-bar-only process
+The application SHALL run as a background process with no dock icon on macOS and no taskbar entry on
+Windows, remaining alive with no window shown.
+
+#### Scenario: Launched on macOS
+- **WHEN** the application is launched on macOS
+- **THEN** no icon appears in the Dock
+- **AND** the process remains running with no window shown
+
+#### Scenario: Launched on Windows
+- **WHEN** the application is launched on Windows
+- **THEN** no taskbar button appears
+- **AND** no console window appears
+
+### Requirement: Service composition root
+The application SHALL build a single dependency-injection container at startup and resolve all
+services from it. A missing or unsatisfiable registration MUST fail at startup, not at first use.
+
+#### Scenario: Container is built at startup
+- **WHEN** the application starts
+- **THEN** the host builds the container and every registered singleton resolves successfully
+
+#### Scenario: A dependency cannot be satisfied
+- **WHEN** a registered service has an unsatisfiable dependency
+- **THEN** the application fails during startup with a diagnostic naming the service
+- **AND** it does not reach the point of showing a tray icon
+
+### Requirement: Clean shutdown
+The application SHALL release native resources on exit so that repeated launches do not leak
+keyboard hooks or audio devices.
+
+#### Scenario: User quits the application
+- **WHEN** the user chooses Quit
+- **THEN** hosted services are stopped, native handles are released, and the process exits with code 0
+
+#### Scenario: Relaunch after quit
+- **WHEN** the application is quit and immediately relaunched
+- **THEN** it starts successfully without reporting a device or hook already in use
+
+### Requirement: Verified platform stack
+The application SHALL depend only on third-party libraries whose required behaviour has been
+demonstrated on both win-x64 and osx-arm64. Each dependency below MUST be proven before code is
+built on top of it.
+
+#### Scenario: Global hook reports both key edges
+- **WHEN** a key combination is pressed and released while another application has focus
+- **THEN** SharpHook reports a press event and a release event on both platforms
+
+#### Scenario: Simulated paste is accepted
+- **WHEN** the SharpHook event simulator sends Ctrl+V, or Cmd+V on macOS, to a focused text editor
+- **THEN** the editor pastes the clipboard contents
+
+#### Scenario: Capture device opens at the requested format
+- **WHEN** a capture device is opened at 48 kHz mono float32
+- **THEN** the device opens on both platforms and delivers samples at that format regardless of the device's native rate
+
+#### Scenario: Tray icon is visible and updatable
+- **WHEN** a tray icon is created and its image is replaced at runtime
+- **THEN** the icon appears in the Windows notification area and the macOS menu bar, and the replacement is reflected
+
+#### Scenario: Encoded audio is well-formed
+- **WHEN** captured audio is encoded to Ogg/Opus
+- **THEN** the resulting file plays back correctly in a standard media player
+
+#### Scenario: A dependency fails its demonstration
+- **WHEN** any of the above cannot be demonstrated on a target platform
+- **THEN** the named fallback is adopted and the affected design is revised before dependent work begins

--- a/openspec/changes/bootstrap-solution/tasks.md
+++ b/openspec/changes/bootstrap-solution/tasks.md
@@ -1,0 +1,32 @@
+## 1. Spikes (do these first — they gate everything else)
+
+- [ ] 1.1 Create a throwaway `spikes/` console project, outside the solution, referencing SharpHook 8.0.0. Verify: run on Windows, press and release Ctrl+Shift+Space while Notepad has focus, and confirm both a press and a release event are logged with the correct modifier mask.
+- [ ] 1.2 Run the same spike on macOS. Verify: both edges logged; record whether the hook needs the main thread and whether a CFRunLoop is required. Note the Accessibility prompt behaviour.
+- [ ] 1.3 Extend the spike with `EventSimulator` sending Ctrl+V (Cmd+V on macOS). Verify: put known text on the clipboard, focus a text editor, run the spike, and confirm the text is pasted on both platforms.
+- [ ] 1.4 Set up a stable development code-signing identity for macOS and sign the spike binary. Verify: grant Accessibility once, rebuild, rerun, and confirm the grant persists without re-prompting.
+- [ ] 1.5 Spike SoundFlow: open a capture device at 48 kHz mono float32 and record 5 seconds to a raw file. Verify: run on both platforms; confirm sample count matches the duration and that it works on a device whose native rate is not 48 kHz (e.g. a 44.1 kHz input).
+- [ ] 1.6 Spike Avalonia 12.1 `TrayIcon`: show an icon, set a tooltip, swap the image on a timer, and add a two-item native menu. Verify: visible in the Windows notification area and the macOS menu bar; record whether the tooltip shows on macOS and whether template images are supported.
+- [ ] 1.7 Spike Concentus 2.2.2 plus a minimal Ogg muxer: encode the 1.5 recording to `.opus`. Verify: the file plays back in VLC or ffplay; also check whether `Concentus.Oggfile` 1.0.7 compiles against Concentus 2.x.
+- [ ] 1.8 Record each spike outcome in `design.md` under Open Questions, marking each resolved or replaced by its fallback. Verify: no Open Question remains unanswered.
+
+## 2. Solution skeleton
+
+- [ ] 2.1 Add `Directory.Build.props`: `net10.0`, `Nullable=enable`, `ImplicitUsings=enable`, `TreatWarningsAsErrors=true`, `LangVersion=latest`. Verify: `dotnet build` succeeds.
+- [ ] 2.2 Add `Directory.Packages.props` with `ManagePackageVersionsCentrally=true` and the versions pinned in the design. Verify: a project referencing a package without a version builds.
+- [ ] 2.3 Create `src/Pisum.Whisper.Core` and add it to `Pisum.Whisper.slnx` via `dotnet sln Pisum.Whisper.slnx add`. Verify: `dotnet build` succeeds.
+- [ ] 2.4 Create `src/Pisum.Whisper.Platform`, referencing Core. Verify: builds.
+- [ ] 2.5 Create `src/Pisum.Whisper.App` (Avalonia 12.1), referencing Core and Platform. Verify: builds.
+- [ ] 2.6 Create `tests/Pisum.Whisper.Core.Tests` (MSTest, FakeItEasy, Shouldly) referencing Core, with one trivial passing test. Verify: `dotnet test` reports 1 passed.
+- [ ] 2.7 Confirm the whole solution builds on both target platforms. Verify: `dotnet build -r win-x64` and `dotnet build -r osx-arm64` both succeed.
+
+## 3. Composition root
+
+- [ ] 3.1 Wire the generic host and `Microsoft.Extensions.DependencyInjection` in the App entry point. Verify: a debug log line at startup proves the container was built.
+- [ ] 3.2 Enable eager validation of the container (validate on build, validate scopes) so a bad registration fails at startup. Verify: temporarily register a service with an unsatisfiable dependency and confirm startup throws naming that service; then revert.
+- [ ] 3.3 Configure the Avalonia `AppBuilder` with `MacOSPlatformOptions { ShowInDock = false }` and add a stub tray icon with a Quit item. Verify: launch on macOS with no Dock icon; launch on Windows with no taskbar button or console window.
+- [ ] 3.4 Implement clean shutdown: stop hosted services and dispose native handles on Quit. Verify: quit and immediately relaunch twice with no device- or hook-in-use error, and confirm exit code 0.
+
+## 4. Documentation
+
+- [ ] 4.1 Replace the placeholder "Status" section in `CLAUDE.md` with the real solution layout and the build, test and run commands. Verify: every command in it runs successfully as written.
+- [ ] 4.2 Update `README.md` with prerequisites and the macOS Accessibility and Microphone permission notes. Verify: a reader can go from clone to running app using only the README.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -18,3 +18,57 @@ schema: spec-driven
 #       - Always include a "Non-goals" section
 #     tasks:
 #       - Break tasks into chunks of max 2 hours
+
+context: |
+  Pisum Whisper — hotkey-driven dictation utility for Windows x64 and macOS Apple Silicon.
+
+  Pipeline: hold (or toggle) a global hotkey -> capture microphone -> encode Opus/WAV
+  -> upload to Google Gemini with the active preset's system prompt -> put the transcript
+  on the clipboard and paste it at the cursor.
+
+  It is a tray-only / menu-bar-only app: no dock icon on macOS, no taskbar entry on Windows.
+  The single settings window starts hidden and hides (rather than quits) on close.
+
+  Tech stack:
+  - .NET 10 (SDK pinned to 10.0.400 in global.json), C#, nullable enabled
+  - Avalonia 12.1 for the tray icon and settings window; CommunityToolkit.Mvvm for MVVM
+  - SharpHook 8 (libuiohook) for the global hotkey — it delivers key DOWN and UP, which
+    Win32 RegisterHotKey and Carbon RegisterEventHotKey do not, and hold-to-record needs both.
+    Its EventSimulator also sends the paste keystroke.
+  - SoundFlow (miniaudio) for microphone capture
+  - Concentus 2.2.2 for Opus encoding, with a hand-rolled Ogg muxer
+  - Serilog + Serilog.Sinks.File for rolling file logs with a runtime-switchable level
+  - System.Text.Json with a source-generated context for settings
+  - MSTest + FakeItEasy + Shouldly for tests
+
+  Solution layout:
+  - src/Pisum.Whisper.Core      — all logic, no UI (Configuration, Audio, Ai, Hotkeys,
+                                  Output, Pipeline, Diagnostics)
+  - src/Pisum.Whisper.Platform  — the small residue of OS-specific code (autostart,
+                                  notifications, shell, macOS permission checks).
+                                  One project, runtime OS switches, no -windows TFM.
+  - src/Pisum.Whisper.App       — Avalonia shell and DI composition root
+  - tests/Pisum.Whisper.Core.Tests
+
+  Reference implementation: W:\github-pisum-transcript is the same product built with
+  Tauri 2 (Rust) + Svelte 5. It is the behavioural spec — wire formats, the recording state
+  machine and its timing constants, the settings schema, and the error taxonomy all come from
+  it. It is NOT a .NET project, so nothing is copied; it is read and re-expressed.
+
+  Deliberately out of scope: local Whisper inference, OpenAI as a provider, input device
+  selection, localization. Deliberately unchanged from the reference: API keys stored in
+  plaintext, and settings living at the home-directory root (~/.pisum-whisper.json).
+
+rules:
+  proposal:
+    - State what changes and why; keep it under 400 words.
+    - Always include a "Non-goals" section.
+    - Name the reference file in W:\github-pisum-transcript that specifies the behaviour, when one exists.
+  design:
+    - Name concrete types, namespaces and NuGet packages — no hand-waving.
+    - Call out anything that differs between Windows and macOS explicitly.
+    - Record rejected alternatives in one short list with the reason.
+  tasks:
+    - Break tasks into chunks of at most 2 hours.
+    - Every task must state how it is verified (unit test, manual step, or command to run).
+    - Put tests in the same task as the code they cover, not in a trailing "write tests" task.


### PR DESCRIPTION
## Summary

Plans the re-creation of [`pisum-transcript`](https://github.com/mschnecke/pisum-transcript) — a Tauri 2 (Rust) + Svelte 5 app — as a .NET 10 application targeting **Windows x64** and **macOS Apple Silicon**.

This is planning only. No source code is added; the solution still has no projects.

**Scope: cloud-only, Gemini-only.** Local Whisper inference is out, despite the repository name. That drops the reference's whole Whisper subsystem — engine, model catalog, downloader, settings tab, mode toggle — and with it its worst build pain: the LLVM/`libclang` prerequisite, `BINDGEN_EXTRA_CLANG_ARGS`, and a 189 KB pre-generated bindgen patch script.

Target pipeline:

```
global hotkey (hold or toggle) -> mic capture -> Opus/WAV encode
  -> Gemini upload with the active preset's system prompt
  -> clipboard + synthetic Ctrl+V / Cmd+V at the cursor
```

plus a tray icon with idle/recording states, a settings window, rolling file logging, and autostart.

## What's in this PR

- `openspec/ROADMAP.md` — dependency graph, change/capability table, standing decisions.
- `openspec/config.yaml` — filled in the `context` and `rules` blocks so every proposal is generated against the chosen stack.
- `openspec/changes/` — 12 change directories.

## Ordering

```
 1 bootstrap-solution
    |-- 2 add-settings-store --+-- 3 add-file-logging
    |                          +-- 6 add-global-hotkey
    |-- 4 add-audio-pipeline ----- 5 add-gemini-transcription  (also needs 2)
    +-- 7 add-text-output
                    |
        8 add-dictation-pipeline    <-- first end-to-end dictation
        9 add-tray-icon -> 10 add-settings-window
       11 add-system-integration -> 12 add-packaging-ci
```

After #1, changes 2/4/7 are parallelizable; after #2, 3/6 likewise. From #8 onward it is strictly sequential.

## Artifact depth

Changes **1-3** carry the full artifact set (`proposal` + `specs` + `design` + `tasks`) and pass `openspec validate`. Changes **4-12** carry `proposal.md` only.

This is deliberate. The four spikes gating change 1 can invalidate downstream design — if SharpHook cannot report key release, or miniaudio cannot resample, the designs for changes 4, 6 and 8 change rather than the code. `openspec validate --changes` reports `3 passed, 9 failed`; every one of those 9 failures is the single "no deltas found" error, i.e. the deferred `specs/`.

## Stack

| Area | Choice | Why |
|---|---|---|
| UI | Avalonia 12.1 | Only mature .NET option with a real menu-bar-only story on both targets |
| Hotkey + paste | SharpHook 8 (libuiohook) | **The load-bearing choice.** Win32 `RegisterHotKey` and Carbon `RegisterEventHotKey` both fire on press only — hold-to-record cannot be built on either. SharpHook delivers both edges |
| Audio | SoundFlow (miniaudio) | Closest analogue to the reference's `cpal`; WASAPI + CoreAudio, natives for both RIDs |
| Opus | Concentus 2.2.2 + hand-rolled Ogg muxer | Pure managed, no native dependency |
| Logging | Serilog | `LoggingLevelSwitch` mirrors the reference's reloadable `EnvFilter` |

## Standing decisions

Recorded so they are not mistaken for oversights:

- **Kept from the reference:** API keys in plaintext; settings at the home-directory root rather than the platform config directory.
- **Fixed relative to the reference:** the prior clipboard is restored after pasting; captured audio is buffered in mono chunks rather than one unbounded list locked inside the audio callback.
- **Out of scope:** local Whisper, OpenAI as a provider, input device selection, localization, auto-update.

## Verification

- `openspec validate --changes` -> 3 passed, 9 failed (all 9 are the deferred `specs/`, as above)
- Package availability, target frameworks and native RIDs were confirmed against the NuGet API rather than assumed — Whisper.net, Avalonia, SharpHook, SoundFlow and Concentus were each inspected for a real `net10.0` target and `win-x64`/`osx-arm64` native assets.

Next step is `/opsx:apply bootstrap-solution`, whose `tasks.md` front-loads the four spikes before any skeleton work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
