### PR TITLE
Spec the pool's category-preservation behaviour

### DIFF
--- a/openspec/changes/add-gemini-transcription/design.md
+++ b/openspec/changes/add-gemini-transcription/design.md
@@ -167,6 +167,27 @@ transcription happens to start from.
 `Interlocked.Increment` over an `int` wraps to `int.MinValue` after ~2.1 billion dictations; the cast
 to `uint` before the modulo is what keeps the index non-negative rather than throwing.
 
+**An aggregated failure keeps the category its parts shared.** The reference flattens every pool
+failure into one `AppError::Transcription("All providers failed: …")` (`ai/pool.rs:91-94`) and lets
+`categorize_error` recover the cause from the message text. It does not recover: the very first
+substring test is `lower.contains("provider")`, and the aggregate message begins *"All providers
+failed"*, so **every** cloud transcription failure in the reference is titled "Configuration Error" —
+a rejected key, an exhausted quota and a dropped connection alike. The four tests below it are
+unreachable through this path.
+
+That makes flattening the category here not a simplification but the reproduction of a defect, and
+the case that matters most is the ordinary one: a single configured key, mistyped, should say so.
+The pool therefore reports the category its failures shared, and falls back to `Transcription` only
+when they genuinely differ:
+
+```csharp
+var category = categories.Distinct().Count() == 1 ? categories[0] : ErrorCategory.Transcription;
+```
+
+`Distinct()` over a five-value enum on a list bounded by the number of configured keys costs nothing
+worth measuring, and the fallback is deliberate rather than clever: when two keys fail for two
+different reasons there is no single true answer, and a generic title beats an arbitrary one.
+
 **`ListModelsAsync` and `TestConnectionAsync` live on `IGeminiKeyProbe`, not on
 `ITranscriptionProvider`.** Both are change 10's, and change 10 calls them against *an API key the
 user has just typed into a textbox* — not a configured, enabled provider entry. The reference already

--- a/openspec/changes/add-gemini-transcription/specs/gemini-transcription/spec.md
+++ b/openspec/changes/add-gemini-transcription/specs/gemini-transcription/spec.md
@@ -108,6 +108,24 @@ on failure SHALL try every remaining enabled entry before reporting failure.
 - **WHEN** provider entries are added, removed or disabled and a transcription is then requested
 - **THEN** the request uses the entries as they currently stand, with no separate rebuild step
 
+### Requirement: An aggregated failure keeps an unambiguous category
+When every enabled provider has failed, the system SHALL report the category they share if they all
+failed the same way, and SHALL fall back to `Transcription` only when they failed in different ways.
+One configured provider is the ordinary case, and reporting its failure as a generic one would
+discard exactly the information categorising at the throw site exists to carry.
+
+#### Scenario: The only configured provider is rejected
+- **WHEN** one enabled provider is configured and its key is rejected
+- **THEN** the aggregated failure is categorised `Authentication`, not `Transcription`
+
+#### Scenario: Every provider is rate limited
+- **WHEN** every enabled provider fails with `RateLimit`
+- **THEN** the aggregated failure is categorised `RateLimit`
+
+#### Scenario: Providers fail in different ways
+- **WHEN** one enabled provider fails with `Authentication` and another with `Network`
+- **THEN** the aggregated failure is categorised `Transcription`
+
 ### Requirement: Recordings too large to send inline are rejected before upload
 The system SHALL reject encoded audio whose size exceeds Gemini's inline-request ceiling, with a
 message naming the size and the format, rather than sending a request that cannot succeed.

--- a/tests/Pisum.Whisper.Core.Tests/Transcription/GeminiProviderPoolTests.cs
+++ b/tests/Pisum.Whisper.Core.Tests/Transcription/GeminiProviderPoolTests.cs
@@ -135,10 +135,11 @@ public sealed class GeminiProviderPoolTests
     }
 
     [TestMethod]
-    public async Task WhenEveryEntryFailsTheSameWay_TheCategorySurvives()
+    public async Task WhenTheOnlyEntryIsRejected_TheCategorySurvives()
     {
-        // A lone misconfigured key must still read as an authentication failure rather than being
-        // flattened into a generic one, which is the whole point of categorising at the throw site.
+        // The reference flattens this into "All providers failed: …", whose first substring test in
+        // categorize_error is contains("provider") — so every cloud failure there is titled
+        // "Configuration Error". A lone mistyped key must say so instead.
         var pool = Pool(
             Store(Entry("a")),
             null,
@@ -148,6 +149,20 @@ public sealed class GeminiProviderPoolTests
             () => pool.TranscribeAsync(Audio, "Transcribe.", CancellationToken.None));
 
         failure.Category.ShouldBe(ErrorCategory.Authentication);
+    }
+
+    [TestMethod]
+    public async Task WhenEveryEntryIsRateLimited_TheCategorySurvives()
+    {
+        var pool = Pool(
+            Store(Entry("a"), Entry("b"), Entry("c")),
+            null,
+            id => throw new TranscriptionException($"{id} is throttled", ErrorCategory.RateLimit));
+
+        var failure = await Should.ThrowAsync<TranscriptionException>(
+            () => pool.TranscribeAsync(Audio, "Transcribe.", CancellationToken.None));
+
+        failure.Category.ShouldBe(ErrorCategory.RateLimit);
     }
 
     [TestMethod]


### PR DESCRIPTION
Follow-up to #22, which merged before this commit was pushed. Tracks #6.

Specs one behaviour that shipped in #22 implemented and tested but recorded nowhere: `GeminiProviderPool` reports the `ErrorCategory` its failures shared when every enabled provider failed the same way, falling back to `Transcription` only when they differ.

## Why it is worth a requirement rather than a comment

Writing up the rationale turned up something sharper than "avoid a regression". The reference flattens every pool failure into `AppError::Transcription("All providers failed: …")` and lets `categorize_error` recover the cause from the message text. It does not recover:

```rust
if lower.contains("no ai providers") || lower.contains("provider") {   // ← FIRST test
    "Configuration Error"
} else if ... "network" ... "api error 401" ... "api error 429" ...    // ← unreachable
```

The aggregate message always begins *"All providers failed"*, which satisfies `contains("provider")`. So **every cloud transcription failure in the reference is titled "Configuration Error"** — rejected key, exhausted quota and dropped connection alike — and the four tests below it can never be reached, because the pool is the only path cloud transcription takes.

Flattening the category here would therefore reproduce a defect rather than simplify. The case that matters most is the ordinary one: a single configured key, mistyped, should say so.

## What's here

- **`specs/gemini-transcription/spec.md`** — a new requirement, *An aggregated failure keeps an unambiguous category*, with three scenarios: the only configured provider rejected → `Authentication`; every provider rate limited → `RateLimit`; providers failing differently → `Transcription`.
- **`design.md`** — the rationale above, including why the fallback is deliberate: when two keys fail for two different reasons there is no single true answer, and a generic title beats an arbitrary one.
- **`GeminiProviderPoolTests.cs`** — the rate-limit test the new scenario needed; it was the one scenario without coverage. The other two were already covered by tests added in #22.

No production code changes — the behaviour already shipped.

## Verification

- `dotnet build Pisum.Whisper.slnx` — 0 warnings, 0 errors.
- `dotnet test Pisum.Whisper.slnx` — 262 passed, 2 skipped, 0 failed.
- `openspec validate add-gemini-transcription` — valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
