### PR TITLE
Record in openspec the corrupt-settings run that closed #20

### DIFF
--- a/openspec/ROADMAP.md
+++ b/openspec/ROADMAP.md
@@ -88,8 +88,9 @@ Changes **1-11** are implemented and archived under `openspec/changes/archive/`,
 `settings-window`, `notifications` and `autostart` specs synced into `openspec/specs/`. Change **12**
 has `proposal.md` only; its `specs`, `design` and `tasks` are written when its turn comes.
 `report-startup-failures` is implemented and archived as well, on 2026-09-02, with its
-`file-logging`, `global-hotkey` and new `startup-diagnostics` specs synced. **None of its three
-by-hand checks has been run**, so they join the table below rather than closing with it.
+`file-logging`, `global-hotkey` and new `startup-diagnostics` specs synced. **One of its three
+by-hand checks has partly run** — 7.1's corrupt-settings reproduction, on 2026-09-02, which closed
+issue #20 — so all three join the table below rather than closing with it.
 
 **Eight archived changes carry unchecked tasks, twenty-three in total, and they are not all macOS.** This
 section previously named changes 8 to 11 and called that "a departure from how 1-7 were closed".
@@ -105,7 +106,7 @@ recording of it changed.
 | 10 `add-settings-window` | 6.2, 6.3, 6.4 | Apple Silicon for 6.2; win-x64 for 6.3 and 6.4 |
 | 11 `add-system-integration` | 7.1, 7.2, 7.3, 7.4 | win-x64 for 7.1; Apple Silicon for 7.2 and the `spikes -- toast` re-run; 7.4 is a headless test plus a glance during 7.1 |
 | `migrate-tests-to-xunit-v3` | 5.4 | win-x64 — confirm Rider still discovers the tests |
-| `report-startup-failures` | 7.1, 7.2, 7.3 | win-x64 for 7.1 and 7.3; Apple Silicon for 7.2. Nothing has been run at all, so the `osascript` dialog has never been drawn |
+| `report-startup-failures` | 7.1, 7.2, 7.3 | win-x64 for 7.1 and 7.3; Apple Silicon for 7.2. 7.1's corrupt-settings reproduction ran on 2026-09-02 and closed #20; its other three, and 7.3 at login, are still owed. The `osascript` dialog has never been drawn |
 
 **Ten of the twenty-three need nothing but the Windows machine this is developed on**, and an
 eleventh is 11's 7.4 headless test. Calling the whole of it "one Apple Silicon sitting" is what has

--- a/openspec/changes/archive/2026-09-02-report-startup-failures/design.md
+++ b/openspec/changes/archive/2026-09-02-report-startup-failures/design.md
@@ -405,8 +405,9 @@ container to `Program` is behaviourally identical on the success path. If a late
   issue #20 holds up as the actionable part of the report, in exchange for a handful of leading
   characters in a case that requires two corruptions to coincide.
 - **Does `MessageBoxW` come to the foreground from a process with no window and no owner?**
-  `MB_SETFOREGROUND` is specified to, but foreground-activation rules on Windows 11 are permissive
-  about refusing. One run of issue #20's reproduction settles it.
+  *Answered for an interactive launch, see Verification results:* foreground, topmost and uncovered.
+  What remains is the launch the question was written about — from the `Run` key at login, where
+  no foreground process has handed the right on. Tracked on issue #30 as the remainder of 7.3.
 - **Does `osascript`'s dialog come to the front when the calling process is not in the dock?** It runs
   in Script Editor's context, which activates — but `ShowInDock = false` is set on Avalonia's options
   and Avalonia is not up at that point, so what this process looks like to the window server is not
@@ -414,3 +415,31 @@ container to `Program` is behaviourally identical on the success path. If a late
 - **Should [1] also degrade the settings window's Logging tab?** That tab shows the log directory path
   and offers "Open Log Folder", both of which mislead when the directory could not be created. Out of
   scope here by the banner non-goal's reasoning, but it is the same defect one surface over.
+
+## Verification results
+
+Run on 2026-09-02 on win-x64 (Windows 11 Pro 10.0.26200) against a Release build of `main` at
+`aeb1e15`, started through `Start-Process` from an interactive session rather than from Explorer —
+equivalent for the purpose here, since a Release build has no console sink and a `WinExe` started
+that way is attached to no console. **Only the corrupt-settings reproduction of 7.1 was run**, the one
+issue #20 describes; the other three reproductions and every macOS row are still open, so 7.1 and 7.2
+stay unticked. The settings file was backed up by hash first and restored byte for byte afterwards.
+
+| # | What was checked | Result |
+|---|---|---|
+| 7.1 | `~/.pisum-whisper.json` replaced with `{ "startWithSystem": true, "hotkey": { BROKEN` and the application launched | **PASS** — a `Settings Error` dialog 683 ms after launch, owned by the launched process, naming the file, `Path: $.hotkey`, `BytePositionInLine: 39` and the log path; dismissing it (by posting `WM_CLOSE`, which a `MB_OK` box answers as OK) exits with code 1; the log gains `[FTL] Startup failed: Settings Error` with the full `SettingsException` beneath it; the corrupt file's hash is unchanged after exit |
+| 7.3 | Whether `MessageBoxW` comes to the foreground from a process with no window and no owner | **PASS for an interactive launch** — `GetForegroundWindow` returned the dialog, `WS_EX_TOPMOST` was set, and `WindowFromPoint` at its centre and both corners resolved to the dialog, so nothing covered it. The login-time launch was not observed |
+
+**Issue #20 closes on the first row.** What it reported was a log file byte-identical before and after
+the failure; the same reproduction now leaves the `Fatal` line and the exception behind it, drained
+before the dialog is shown, and the process ends with a non-zero exit code instead of an unhandled
+exception on a stderr nothing reads.
+
+**What was disclosed is what 1.1 predicted.** The dialog and the log quote the one offending character
+(`'B'`) and name the property (`$.hotkey`); no value from the file appears in either.
+
+**Three reproductions of 7.1 were not run, and the login-time half of 7.3 was not either.** An
+unwritable settings file with none present, `AddNativeOutput` commented out to fail `ValidateOnBuild`,
+and a renamed `tray-*.png` all remain, as does whether the dialog is foreground when the process is
+started by the `Run` key at login rather than by something already holding the foreground. All four
+are tracked on issue #30.


### PR DESCRIPTION
Touches `openspec/` only. Records the one by-hand check of `report-startup-failures` that has now run,
and corrects the roadmap line that said none had.

Relates to #20 (closed on this run) and #30 (carries what remains).

## What ran

The reproduction issue #20 describes, on 2026-09-02 against a Release build of `main` at aeb1e15,
launched with no console:

- A native **Settings Error** dialog appeared 683 ms after launch, foreground and topmost, naming the
  file, `$.hotkey` and the byte position, and pointing at the log. It quotes the one offending
  character and no value from the file.
- Dismissing it exited the process with code 1.
- The log gained `[FTL] Startup failed: Settings Error` with the full exception beneath it.
- The corrupt file was left byte for byte as written.

## What this records

- The archived change's `design.md` gains a *Verification results* section in change 7's format, and
  its `MessageBoxW` foreground question is marked answered for an interactive launch only.
- `ROADMAP.md`'s *Artifact status* no longer says nothing from the change has run; its table row names
  what ran and what is owed.

## Not done, and deliberately not ticked

The other three reproductions of task 7.1 (an unwritable settings file, a container failing
`ValidateOnBuild`, a missing tray asset), the login-time half of 7.3, and all of 7.2 on Apple Silicon.
All are on #30 and #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
