### PR TITLE
Record in openspec the macOS text-output run that closes task 7/5.4

### DIFF
--- a/openspec/changes/archive/2026-08-31-add-text-output/design.md
+++ b/openspec/changes/archive/2026-08-31-add-text-output/design.md
@@ -384,16 +384,19 @@ this change.
 Notepad both read the clipboard within 50 ms, so the constant is kept with a twentyfold margin. An
 Office document, a terminal, and everything on macOS are still unmeasured.
 
-**Does S1b pass on macOS once the app is signed?** Task 1.4 owns the signing identity; until it is
-done, the macOS half of this change cannot be verified end to end and the `ClipboardOnly` outcome is
-what a macOS user will get. This change does not close that row of the platform verification matrix.
+**Does S1b pass on macOS once the app is signed?** *Answered 2026-09-02, see Verification results —
+not the way this question assumed.* Task 1.4 turned out not to need a signing identity at all: the
+Accessibility/Input Monitoring grant that matters belongs to the terminal a dev build is launched
+from, not to the binary's own signature. With that grant present, `DeliverAsync` pastes correctly and
+repeatably through the real `MacOsClipboard`/`MacOsPasteProbe` — confirming the "a process that got
+as far as a dictation is one whose paste is expected to work" reasoning above without ever needing
+change 12's signing to land first.
 
 ## Verification results
 
 Run on 2026-08-31 on win-x64 (Windows 11 Pro 10.0.26200) through a throwaway harness in the
 scratchpad that drives the real `WindowsClipboard`, `WindowsPasteProbe`, `TextOutput` and
-`EventSimulator` against real windows. **No macOS run has happened**, so every osx-arm64 row below is
-still open and tasks 3.5, 3.6 and 5.4 remain unticked.
+`EventSimulator` against real windows.
 
 | # | What was checked | Result |
 |---|---|---|
@@ -419,4 +422,38 @@ select-all/copy read-back that this harness can use.
 - *Clipboard history exclusion (3.3).* `HKCU\Software\Microsoft\Clipboard\EnableClipboardHistory` is
   not set on this machine, so Win+V retains nothing from any application and the check would pass
   vacuously. It needs a machine with clipboard history switched on.
-- *Everything macOS (3.5, 3.6, 5.4).* No Apple Silicon host was available to this run.
+- *Everything macOS except 5.4 (3.5, 3.6).* No Apple Silicon host was available to this run; 5.4 is
+  covered by the macOS run below.
+
+### macOS run — 2026-09-02 (issue #31, task 7/5.4)
+
+Run on an Apple M4 (macOS 26.6.2) through a throwaway harness in the scratchpad, mirroring the
+win-x64 harness above: it builds the real `MacOsClipboard`, `MacOsPasteProbe` and `TextOutput` through
+`AddTextOutput()` + `AddNativeOutput()` and calls `DeliverAsync` against a real TextEdit window, then
+independently verifies what landed by selecting all and copying back out with the same
+`EventSimulator` the production paste uses.
+
+| # | What was checked | Result |
+|---|---|---|
+| 5.4 | Full delivery into TextEdit, `IPasteProbe.CanPaste()` true throughout | **PASS** — outcome `Pasted` every time the target window was confirmed frontmost; the token landed correctly in 4 of 4 valid trials |
+
+**S1b's FAIL does not reproduce through the shipped code path.** `IPasteProbe.CanPaste()` (which
+wraps `AXIsProcessTrusted()`) returned `true` on every run, and `DeliverAsync` pasted the token into
+TextEdit every time the harness confirmed TextEdit was actually frontmost first. This closes the
+macOS half of task 5.4 in favour of the design's existing decision — the paste stays as designed, and
+the clipboard-only fallback kept in reserve is not adopted.
+
+**Two invalid trials, both harness artifacts rather than paste failures, are worth recording so
+nobody re-diagnoses them as regressions.** First, an early run's own verification step (its
+select-all/copy, not `DeliverAsync`'s paste) fired while this session's own terminal — not
+TextEdit — was frontmost, so it captured and echoed the terminal's on-screen contents instead of
+TextEdit's; nothing indicates `DeliverAsync`'s own paste went astray in that run, only the harness's
+follow-up check. Second, a run against a document reused from a `killall -9`-terminated previous run
+came back with the new token concatenated after an old one — TextEdit's session-resume state, not a
+clean empty document, unlike spike `PasteSpike.cs`'s explicit clear-before-paste step which this
+harness initially omitted. Both are fixed in the harness by confirming (via `System Events`'
+frontmost-process name) that TextEdit is actually the active application immediately before both the
+paste and the verification copy, aborting the trial rather than reporting a false result if it is not
+— after which every trial passed cleanly. **Takeaway for anyone driving synthetic keystrokes from a
+process running in the same interactive session as its own terminal: verify the target is frontmost
+immediately before firing, since focus is not guaranteed to stay where an `activate` call put it.**


### PR DESCRIPTION
Touches `openspec/` only. Re-tests task 7/5.4 from #31 (does S1b's macOS paste `FAIL` reproduce
through the shipped `TextOutput`/`MacOsClipboard`/`MacOsPasteProbe` code path?) and records the
answer.

Relates to #31 (task 7/5.4 ticked on this run).

## What ran

A throwaway harness on an Apple M4 (macOS 26.6.2), built alongside PR #38's harness for task 1.4: it
wires the real `MacOsClipboard`, `MacOsPasteProbe` and `TextOutput` through
`AddTextOutput()` + `AddNativeOutput()` (no spike code involved) and calls `DeliverAsync` against a
real TextEdit window, then independently verifies what landed by selecting all and copying back out
with the same `EventSimulator` the production paste uses.

## What this records

- `add-text-output`'s `design.md` gains a *macOS run — 2026-09-02* section: `IPasteProbe.CanPaste()`
  returned `true` throughout, and `DeliverAsync` pasted the token into TextEdit in every valid trial.
  S1b's original spike `FAIL` does not reproduce through the shipped code path.
- Two runs that initially looked like failures were harness artifacts, not paste defects, and are
  written up so nobody re-diagnoses them later: one run's own verification step fired against this
  session's own terminal instead of TextEdit; one run pasted onto a TextEdit document that
  session-resume brought back non-empty rather than a fresh document.
- The "Does S1b pass on macOS once the app is signed?" open question is answered — not the way it
  assumed, since task 1.4 (#31, PR #38) found no signing identity was actually needed. This confirms
  the change's existing decision to keep the paste as designed on macOS rather than take the
  clipboard-only fallback kept in reserve.

## Not done, and deliberately not the point of this PR

Tasks 7/3.6 (`MacOsPasteProbe` with and without Accessibility) and 7/3.5
(`org.nspasteboard.ConcealedType`) are untouched. Everything else in #31's checklist is untouched too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5BiqqQGW7EMJSsoC2DHUs