### PR TITLE
Record in openspec the MacOsPasteProbe run that closes task 7/3.6

### DIFF
--- a/openspec/changes/archive/2026-08-31-add-text-output/design.md
+++ b/openspec/changes/archive/2026-08-31-add-text-output/design.md
@@ -392,8 +392,8 @@ what a macOS user will get. This change does not close that row of the platform 
 
 Run on 2026-08-31 on win-x64 (Windows 11 Pro 10.0.26200) through a throwaway harness in the
 scratchpad that drives the real `WindowsClipboard`, `WindowsPasteProbe`, `TextOutput` and
-`EventSimulator` against real windows. **No macOS run has happened**, so every osx-arm64 row below is
-still open and tasks 3.5, 3.6 and 5.4 remain unticked.
+`EventSimulator` against real windows. **No macOS run had happened at the time**, so every osx-arm64
+row below was still open; task 3.6 is closed below, tasks 3.5 and 5.4 remain unticked.
 
 | # | What was checked | Result |
 |---|---|---|
@@ -419,4 +419,26 @@ select-all/copy read-back that this harness can use.
 - *Clipboard history exclusion (3.3).* `HKCU\Software\Microsoft\Clipboard\EnableClipboardHistory` is
   not set on this machine, so Win+V retains nothing from any application and the check would pass
   vacuously. It needs a machine with clipboard history switched on.
-- *Everything macOS (3.5, 3.6, 5.4).* No Apple Silicon host was available to this run.
+- *Everything macOS except 3.6 (3.5, 5.4).* No Apple Silicon host was available to this run; 3.6 is
+  covered by the macOS run below.
+
+### macOS run — 2026-09-02 (issue #31, task 7/3.6)
+
+Run on an Apple M4 (macOS 26.6.2). `MacOsPasteProbe.CanPaste()` is a direct, argument-free
+`AXIsProcessTrusted()` P/Invoke with no exception path (`src/Pisum.Whisper.Platform/Output/MacOsPasteProbe.cs`)
+and no existing test exercises the real call, so this checks the actual OS answer in both states
+rather than the DI wiring `NativeOutputRegistrationTests` already covers.
+
+A throwaway console harness in the scratchpad referenced `Pisum.Whisper.Platform` directly and
+printed `new MacOsPasteProbe().CanPaste()` — no app, no DI container.
+
+| # | What was checked | Result |
+|---|---|---|
+| 3.6 | `CanPaste()` with Accessibility granted (run through Rider's terminal, which holds the grant — see task 1.4) | **PASS** — `True` |
+| 3.6 | `CanPaste()` without Accessibility (the same built binary, run from a plain `Terminal.app` that has never been granted) | **PASS** — `False` |
+
+Neither run produced a system Accessibility prompt, matching the code: `AXIsProcessTrusted()` takes
+no prompt option. Both answers match `MacOsPasteProbe`'s own doc comment — "definitive rather than
+heuristic" — with no crash and no exception in either state. This closes 3.6; `TextOutput`'s handling
+of a `false` result (skip the paste, keep the clipboard write, return `ClipboardOnly`) is exercised by
+`TextOutputTestBase`'s `FakePasteProbe` already and was not re-derived here.


### PR DESCRIPTION
Touches `openspec/` only. Re-tests task 7/3.6 from #31 (`MacOsPasteProbe` with and without
Accessibility) directly, without going through the full `TextOutput`/`DeliverAsync` pipeline that
task 7/5.4 (PR #39) already exercised.

Relates to #31 (task 7/3.6 ticked on this run).

## What ran

A throwaway console harness in the scratchpad referenced `Pisum.Whisper.Platform` directly and
printed `new MacOsPasteProbe().CanPaste()` — no app, no DI container — on an Apple M4 (macOS 26.6.2):

- Once run through Rider's terminal, which holds the Accessibility grant (task 1.4, PR #38).
- Once run from a plain `Terminal.app` that has never been granted Accessibility on this machine.

## What this records

- `add-text-output`'s `design.md` gains a *macOS run — 2026-09-02 (task 7/3.6)* section:
  `CanPaste()` returned `True` with the grant and `False` without it, with no system prompt in
  either state — `AXIsProcessTrusted()` takes no prompt option — and no crash either way. Matches
  the class's own doc comment ("definitive rather than heuristic") exactly.
- The Verification results' "no Apple Silicon host" note narrows from "3.5, 3.6, 5.4" to "3.5, 5.4",
  since 3.6 is closed here.

## Not done, and deliberately not the point of this PR

`TextOutput`'s handling of a `false` `CanPaste()` result (skip the paste, keep the clipboard write,
return `ClipboardOnly`) already has coverage via `TextOutputTestBase`'s `FakePasteProbe` and was not
re-derived here — this PR is only about the real P/Invoke's answer in both TCC states, which had no
test anywhere before. Task 7/3.5 (`org.nspasteboard.ConcealedType`) and everything from change 8
onward in #31's checklist are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5BiqqQGW7EMJSsoC2DHUs