### PR TITLE
Record the abandoned refused-microphone attempt for task 8/6.4

### DIFF
--- a/openspec/changes/archive/2026-09-01-add-dictation-pipeline/design.md
+++ b/openspec/changes/archive/2026-09-01-add-dictation-pipeline/design.md
@@ -456,7 +456,17 @@ of this change is to run one and record the result here.
 
 **Does a denied macOS microphone grant present as "no input device"?** Unverified — S2 passed on the
 M4 with the microphone accessible. It decides whether the deferred "Microphone Access Required"
-message ever needs a home, and if so whether `AudioException` needs a category.
+message ever needs a home, and if so whether `AudioException` needs a category. **Attempted
+2026-09-02 (issue #31, task 8/6.4) and abandoned before reaching a denied grant to test against.**
+Microphone access, unlike Accessibility, is tracked in the *user*-level TCC database and attributed
+directly to the app binary's own file path rather than to a responsible parent process —
+`Pisum.Whisper.App` already held its own grant there, separate from Rider's. `tccutil reset
+Microphone <path>` refused it ("No such bundle identifier"): `tccutil` expects a bundle identifier,
+which an unbundled dev build does not have. Writing the revocation directly into the live TCC
+database was ruled out as too risky — it is an actively-managed system security database, not a
+config file, and a manual write while `tccd` holds it open risks corrupting it or leaving it
+inconsistent with the daemon's own state. Revoking it by hand through System Settings → Privacy &
+Security → Microphone was offered and declined for this sitting. Still unverified.
 
 **Should a timed-out or failed dictation keep its audio?** Today the encoded bytes are dropped, as in
 the reference, and the user re-speaks. Retaining them would make a retry possible and is cheap now


### PR DESCRIPTION
Touches `openspec/` only. Task 8/6.4 from #31 has two halves; this records why only one closed.

Relates to #31 (task 8/6.4 stays unticked — this is a partial record, not a completion).

## What's already confirmed

The end-to-end dictation half of 8/6.4 is confirmed twice over, in tasks already recorded elsewhere:
task 9/4.2's real hold-to-record dictations, and task 11/7.2's launchd-started instance — both
delivered correctly.

## What was attempted and abandoned

The refused-microphone half. Unlike Accessibility (tracked in the *system*-level TCC database and
attributed to a responsible parent process — Rider, for everything else this whole verification
effort has run), Microphone access is tracked in the *user*-level TCC database and attributed
directly to the calling binary's own file path. `Pisum.Whisper.App` already held its own grant
there, separate from Rider's.

`tccutil reset Microphone <path>` refused it — "No such bundle identifier" — because `tccutil`
expects a bundle identifier, which an unbundled dev build doesn't have. Writing the revocation
directly into the live TCC database was ruled out: it's an actively-managed system security
database, not a config file, and a manual write while `tccd` holds it open risks corrupting it or
leaving it inconsistent with the daemon's own state. Revoking it by hand through System Settings →
Privacy & Security → Microphone was offered and declined for this sitting.

`add-dictation-pipeline`'s `design.md` records the attempt beside its "Does a denied macOS
microphone grant present as no input device?" open question, which stays unanswered — so nobody
re-attempts the same dead end (`tccutil` on a path) next time this is picked up.

## Not done, and deliberately not the point of this PR

The refused-grant case itself remains genuinely open. Only the final matrix-rollup task remains in
#31 after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5BiqqQGW7EMJSsoC2DHUs